### PR TITLE
Update expected errors

### DIFF
--- a/testset/invalid/format/languages/__TestExpectation.json
+++ b/testset/invalid/format/languages/__TestExpectation.json
@@ -11,7 +11,7 @@
     },
     {
       "file": "emptyObject.json",
-      "error": "PropertyNull"
+      "error": "PropertyMissing"
     },
     {
       "file": "missing.json",

--- a/testset/invalid/format/nodes/concept/language/__TestExpectation.json
+++ b/testset/invalid/format/nodes/concept/language/__TestExpectation.json
@@ -11,7 +11,7 @@
     },
     {
       "file": "nullValue.json",
-      "error": "KeyFormat"
+      "error": "PropertyNull"
     },
     {
       "file": "numValue.json",

--- a/testset/invalid/format/nodes/concept/version/__TestExpectation.json
+++ b/testset/invalid/format/nodes/concept/version/__TestExpectation.json
@@ -11,8 +11,7 @@
     },
     {
       "file": "nullValue.json",
-      "error": "LanguageUnknown",
-      "TODO": "should give an error on key format being null"
+      "error": "PropertyNull"
     },
     {
       "file": "numValue.json",

--- a/testset/invalid/format/nodes/containments/containment/language/__TestExpectation.json
+++ b/testset/invalid/format/nodes/containments/containment/language/__TestExpectation.json
@@ -11,7 +11,7 @@
     },
     {
       "file": "nullValue.json",
-      "error": "KeyFormat"
+      "error": "PropertyNull"
     },
     {
       "file": "numValue.json",

--- a/testset/invalid/format/nodes/containments/containment/version/__TestExpectation.json
+++ b/testset/invalid/format/nodes/containments/containment/version/__TestExpectation.json
@@ -11,8 +11,7 @@
     },
     {
       "file": "nullValue.json",
-      "error": "LanguageUnknown",
-      "TODO": "should give an error on key format being null"
+      "error": "PropertyNull"
     },
     {
       "file": "numValue.json",

--- a/testset/invalid/format/nodes/properties/property/language/__TestExpectation.json
+++ b/testset/invalid/format/nodes/properties/property/language/__TestExpectation.json
@@ -11,7 +11,7 @@
     },
     {
       "file": "nullValue.json",
-      "error": "KeyFormat"
+      "error": "PropertyNull"
     },
     {
       "file": "numValue.json",

--- a/testset/invalid/format/nodes/properties/property/version/__TestExpectation.json
+++ b/testset/invalid/format/nodes/properties/property/version/__TestExpectation.json
@@ -11,8 +11,7 @@
     },
     {
       "file": "nullValue.json",
-      "error": "LanguageUnknown",
-      "TODO": "should give an error on key format being null"
+      "error": "PropertyNull"
     },
     {
       "file": "numValue.json",

--- a/testset/invalid/format/nodes/references/reference/language/__TestExpectation.json
+++ b/testset/invalid/format/nodes/references/reference/language/__TestExpectation.json
@@ -11,7 +11,7 @@
     },
     {
       "file": "nullValue.json",
-      "error": "KeyFormat"
+      "error": "PropertyNull"
     },
     {
       "file": "numValue.json",

--- a/testset/invalid/format/nodes/references/reference/version/__TestExpectation.json
+++ b/testset/invalid/format/nodes/references/reference/version/__TestExpectation.json
@@ -11,8 +11,7 @@
     },
     {
       "file": "nullValue.json",
-      "error": "LanguageUnknown",
-      "TODO": "should give an error on key format being null"
+      "error": "PropertyNull"
     },
     {
       "file": "numValue.json",


### PR DESCRIPTION
Change the expected errors, mostly to PropertyNull. For now, this is in line with the refactored validation in lionweb-typescript. Will need to reconcile with the validation document at some later moment in time.