### PR TITLE
Add test case for CompositeCommand and CompositeEvent back again

### DIFF
--- a/delta/command/CompositeCommand.delta.json
+++ b/delta/command/CompositeCommand.delta.json
@@ -1,0 +1,83 @@
+{
+  "messageKind": "CompositeCommand",
+  "parts": [
+    {
+      "messageKind": "AddProperty",
+      "node": "nodeId",
+      "property": {
+        "language": "MyLang",
+        "version": "4",
+        "key": "MyProperty"
+      },
+      "newValue": "hello",
+      "commandId": "cmdId0",
+      "additionalInfos": [
+        {
+          "kind": "msgKind",
+          "message": "Human message",
+          "data": [
+            {
+              "key": "dataKey",
+              "value": "dataValue"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "messageKind": "ChangeClassifier",
+      "node": "nodeId",
+      "newClassifier": {
+        "language": "MyLang",
+        "version": "3",
+        "key": "MyClassifier"
+      },
+      "commandId": "cmdId1",
+      "additionalInfos": [
+        {
+          "kind": "msgKind",
+          "message": "Human message",
+          "data": [
+            {
+              "key": "dataKey",
+              "value": "dataValue"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "messageKind": "CompositeCommand",
+      "parts": [
+        {
+          "messageKind": "DeleteChild",
+          "parent": "nodeId",
+          "containment": {
+            "language": "MyLang",
+            "version": "4",
+            "key": "MyContainment"
+          },
+          "index": 3,
+          "deletedChild": "a",
+          "commandId": "cmdId2",
+          "additionalInfos": []
+        }
+      ],
+      "commandId": "cmdId3",
+      "additionalInfos": []
+    }
+  ],
+  "commandId": "cmdId4",
+  "additionalInfos": [
+    {
+      "kind": "msgKind",
+      "message": "Human message",
+      "data": [
+        {
+          "key": "dataKey",
+          "value": "dataValue"
+        }
+      ]
+    }
+  ]
+}

--- a/delta/event/CompositeEvent.delta.json
+++ b/delta/event/CompositeEvent.delta.json
@@ -128,6 +128,13 @@
       "additionalInfos": []
     }
   ],
+  "originCommands": [
+    {
+      "participationId": "partId",
+      "commandId": "cmdId"
+    }
+  ],
+  "sequenceNumber": 121,
   "additionalInfos": [
     {
       "kind": "msgKind",

--- a/delta/event/CompositeEvent.delta.json
+++ b/delta/event/CompositeEvent.delta.json
@@ -1,0 +1,143 @@
+{
+  "messageKind": "CompositeEvent",
+  "parts": [
+    {
+      "messageKind": "ChildAdded",
+      "parent": "nodeId",
+      "newChild": {
+        "nodes": [
+          {
+            "id": "a",
+            "classifier": {
+              "language": "myLang",
+              "version": "1",
+              "key": "myConcept"
+            },
+            "properties": [],
+            "containments": [],
+            "references": [],
+            "annotations": [],
+            "parent": null
+          },
+          {
+            "id": "b",
+            "classifier": {
+              "language": "myLang",
+              "version": "1",
+              "key": "myConcept"
+            },
+            "properties": [],
+            "containments": [],
+            "references": [],
+            "annotations": [],
+            "parent": "a"
+          }
+        ]
+      },
+      "containment": {
+        "language": "MyLang",
+        "version": "4",
+        "key": "MyContainment"
+      },
+      "index": 3,
+      "originCommands": [
+        {
+          "participationId": "partId",
+          "commandId": "cmdId"
+        },
+        {
+          "participationId": "otherPartId",
+          "commandId": "otherCmdId"
+        }
+      ],
+      "sequenceNumber": 122,
+      "additionalInfos": [
+        {
+          "kind": "msgKind",
+          "message": "Human message",
+          "data": [
+            {
+              "key": "dataKey",
+              "value": "dataValue"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "messageKind": "PartitionDeleted",
+      "deletedPartition": "a",
+      "deletedDescendants": [
+        "b"
+      ],
+      "originCommands": [
+        {
+          "participationId": "partId",
+          "commandId": "cmdId"
+        },
+        {
+          "participationId": "otherPartId",
+          "commandId": "otherCmdId"
+        }
+      ],
+      "sequenceNumber": 123,
+      "additionalInfos": [
+        {
+          "kind": "msgKind",
+          "message": "Human message",
+          "data": [
+            {
+              "key": "dataKey",
+              "value": "dataValue"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "messageKind": "ChildDeleted",
+      "parent": "nodeId",
+      "deletedChild": "a",
+      "deletedDescendants": [],
+      "containment": {
+        "language": "MyLang",
+        "version": "4",
+        "key": "MyContainment"
+      },
+      "index": 3,
+      "originCommands": [
+        {
+          "participationId": "partId",
+          "commandId": "cmdId"
+        }
+      ],
+      "sequenceNumber": 124,
+      "additionalInfos": []
+    },
+    {
+      "messageKind": "ErrorEvent",
+      "errorCode": "myErrorCode",
+      "message": "something is not right",
+      "originCommands": [
+        {
+          "participationId": "partId",
+          "commandId": "cmdId"
+        }
+      ],
+      "sequenceNumber": 125,
+      "additionalInfos": []
+    }
+  ],
+  "additionalInfos": [
+    {
+      "kind": "msgKind",
+      "message": "Human message",
+      "data": [
+        {
+          "key": "dataKey",
+          "value": "dataValue"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This reverts commit e151d6b094b8f2827f254b25f5ca96dbe676503f. + does renaming `protocolMessages` &rarr; `additionalInfos`.

Depends on https://github.com/LionWeb-io/specification/pull/457 for the test to go green.