### PR TITLE
add secondary containment and restricted annotation

### DIFF
--- a/cs/LionWeb.Integration.Languages/Generated/V2023_1/TestLanguage.g.cs
+++ b/cs/LionWeb.Integration.Languages/Generated/V2023_1/TestLanguage.g.cs
@@ -32,15 +32,17 @@ public partial class TestLanguageLanguage : LanguageBase<ITestLanguageFactory>
 		_dataTypeTestConcept_integerValue_1 = new(() => new PropertyBase<TestLanguageLanguage>("DataTypeTestConcept-integerValue_1", DataTypeTestConcept, this) { Key = "DataTypeTestConcept-integerValue_1", Name = "integerValue_1", Optional = false, Type = _builtIns.Integer });
 		_dataTypeTestConcept_stringValue_0_1 = new(() => new PropertyBase<TestLanguageLanguage>("DataTypeTestConcept-stringValue_0_1", DataTypeTestConcept, this) { Key = "DataTypeTestConcept-stringValue_0_1", Name = "stringValue_0_1", Optional = true, Type = _builtIns.String });
 		_dataTypeTestConcept_stringValue_1 = new(() => new PropertyBase<TestLanguageLanguage>("DataTypeTestConcept-stringValue_1", DataTypeTestConcept, this) { Key = "DataTypeTestConcept-stringValue_1", Name = "stringValue_1", Optional = false, Type = _builtIns.String });
-		_linkTestConcept = new(() => new ConceptBase<TestLanguageLanguage>("LinkTestConcept", this) { Key = "LinkTestConcept", Name = "LinkTestConcept", Abstract = false, Partition = false, ImplementsLazy = new(() => [_builtIns.INamed]), FeaturesLazy = new(() => [LinkTestConcept_containment_0_1, LinkTestConcept_containment_0_n, LinkTestConcept_containment_1, LinkTestConcept_containment_1_n, LinkTestConcept_reference_0_1, LinkTestConcept_reference_0_n, LinkTestConcept_reference_1, LinkTestConcept_reference_1_n]) });
+		_linkTestConcept = new(() => new ConceptBase<TestLanguageLanguage>("LinkTestConcept", this) { Key = "LinkTestConcept", Name = "LinkTestConcept", Abstract = false, Partition = false, ImplementsLazy = new(() => [_builtIns.INamed]), FeaturesLazy = new(() => [LinkTestConcept_containment_0_1, LinkTestConcept_containment_0_n, LinkTestConcept_containment_1, LinkTestConcept_containment_1_n, LinkTestConcept_otherContainment_0_1, LinkTestConcept_reference_0_1, LinkTestConcept_reference_0_n, LinkTestConcept_reference_1, LinkTestConcept_reference_1_n]) });
 		_linkTestConcept_containment_0_1 = new(() => new ContainmentBase<TestLanguageLanguage>("LinkTestConcept-containment_0_1", LinkTestConcept, this) { Key = "LinkTestConcept-containment_0_1", Name = "containment_0_1", Optional = true, Multiple = false, Type = LinkTestConcept });
 		_linkTestConcept_containment_0_n = new(() => new ContainmentBase<TestLanguageLanguage>("LinkTestConcept-containment_0_n", LinkTestConcept, this) { Key = "LinkTestConcept-containment_0_n", Name = "containment_0_n", Optional = true, Multiple = true, Type = LinkTestConcept });
 		_linkTestConcept_containment_1 = new(() => new ContainmentBase<TestLanguageLanguage>("LinkTestConcept-containment_1", LinkTestConcept, this) { Key = "LinkTestConcept-containment_1", Name = "containment_1", Optional = false, Multiple = false, Type = LinkTestConcept });
 		_linkTestConcept_containment_1_n = new(() => new ContainmentBase<TestLanguageLanguage>("LinkTestConcept-containment_1_n", LinkTestConcept, this) { Key = "LinkTestConcept-containment_1_n", Name = "containment_1_n", Optional = false, Multiple = true, Type = LinkTestConcept });
+		_linkTestConcept_otherContainment_0_1 = new(() => new ContainmentBase<TestLanguageLanguage>("LinkTestConcept-otherContainment_0_1", LinkTestConcept, this) { Key = "LinkTestConcept-otherContainment_0_1", Name = "otherContainment_0_1", Optional = true, Multiple = false, Type = LinkTestConcept });
 		_linkTestConcept_reference_0_1 = new(() => new ReferenceBase<TestLanguageLanguage>("LinkTestConcept-reference_0_1", LinkTestConcept, this) { Key = "LinkTestConcept-reference_0_1", Name = "reference_0_1", Optional = true, Multiple = false, Type = LinkTestConcept });
 		_linkTestConcept_reference_0_n = new(() => new ReferenceBase<TestLanguageLanguage>("LinkTestConcept-reference_0_n", LinkTestConcept, this) { Key = "LinkTestConcept-reference_0_n", Name = "reference_0_n", Optional = true, Multiple = true, Type = LinkTestConcept });
 		_linkTestConcept_reference_1 = new(() => new ReferenceBase<TestLanguageLanguage>("LinkTestConcept-reference_1", LinkTestConcept, this) { Key = "LinkTestConcept-reference_1", Name = "reference_1", Optional = false, Multiple = false, Type = LinkTestConcept });
 		_linkTestConcept_reference_1_n = new(() => new ReferenceBase<TestLanguageLanguage>("LinkTestConcept-reference_1_n", LinkTestConcept, this) { Key = "LinkTestConcept-reference_1_n", Name = "reference_1_n", Optional = false, Multiple = true, Type = LinkTestConcept });
+		_restrictedTestAnnotation = new(() => new AnnotationBase<TestLanguageLanguage>("RestrictedTestAnnotation", this) { Key = "RestrictedTestAnnotation", Name = "RestrictedTestAnnotation", AnnotatesLazy = new(() => LinkTestConcept), ImplementsLazy = new(() => [_builtIns.INamed]) });
 		_secondTestEnumeration = new(() => new EnumerationBase<TestLanguageLanguage>("SecondTestEnumeration", this) { Key = "SecondTestEnumeration", Name = "SecondTestEnumeration", LiteralsLazy = new(() => [SecondTestEnumeration_literal1, SecondTestEnumeration_literal2, SecondTestEnumeration_literal3]) });
 		_secondTestEnumeration_literal1 = new(() => new EnumerationLiteralBase<TestLanguageLanguage>("SecondTestEnumeration-literal1", SecondTestEnumeration, this) { Key = "SecondTestEnumeration-literal1", Name = "literal1" });
 		_secondTestEnumeration_literal2 = new(() => new EnumerationLiteralBase<TestLanguageLanguage>("SecondTestEnumeration-literal2", SecondTestEnumeration, this) { Key = "SecondTestEnumeration-literal2", Name = "literal2" });
@@ -59,7 +61,7 @@ public partial class TestLanguageLanguage : LanguageBase<ITestLanguageFactory>
 	}
 
 	/// <inheritdoc/>
-        public override IReadOnlyList<LanguageEntity> Entities => [DataTypeTestConcept, LinkTestConcept, SecondTestEnumeration, TestAnnotation, TestEnumeration, TestPartition];
+        public override IReadOnlyList<LanguageEntity> Entities => [DataTypeTestConcept, LinkTestConcept, RestrictedTestAnnotation, SecondTestEnumeration, TestAnnotation, TestEnumeration, TestPartition];
 	/// <inheritdoc/>
         public override IReadOnlyList<Language> DependsOn => [];
 
@@ -117,6 +119,9 @@ public partial class TestLanguageLanguage : LanguageBase<ITestLanguageFactory>
 	private readonly Lazy<Containment> _linkTestConcept_containment_1_n;
 	public Containment LinkTestConcept_containment_1_n => _linkTestConcept_containment_1_n.Value;
 
+	private readonly Lazy<Containment> _linkTestConcept_otherContainment_0_1;
+	public Containment LinkTestConcept_otherContainment_0_1 => _linkTestConcept_otherContainment_0_1.Value;
+
 	private readonly Lazy<Reference> _linkTestConcept_reference_0_1;
 	public Reference LinkTestConcept_reference_0_1 => _linkTestConcept_reference_0_1.Value;
 
@@ -128,6 +133,9 @@ public partial class TestLanguageLanguage : LanguageBase<ITestLanguageFactory>
 
 	private readonly Lazy<Reference> _linkTestConcept_reference_1_n;
 	public Reference LinkTestConcept_reference_1_n => _linkTestConcept_reference_1_n.Value;
+
+	private readonly Lazy<Annotation> _restrictedTestAnnotation;
+	public Annotation RestrictedTestAnnotation => _restrictedTestAnnotation.Value;
 
 	private readonly Lazy<Enumeration> _secondTestEnumeration;
 	public Enumeration SecondTestEnumeration => _secondTestEnumeration.Value;
@@ -178,6 +186,8 @@ public partial interface ITestLanguageFactory : INodeFactory
 	public DataTypeTestConcept CreateDataTypeTestConcept();
 	public LinkTestConcept NewLinkTestConcept(string id);
 	public LinkTestConcept CreateLinkTestConcept();
+	public RestrictedTestAnnotation NewRestrictedTestAnnotation(string id);
+	public RestrictedTestAnnotation CreateRestrictedTestAnnotation();
 	public TestAnnotation NewTestAnnotation(string id);
 	public TestAnnotation CreateTestAnnotation();
 	public TestPartition NewTestPartition(string id);
@@ -199,6 +209,8 @@ public class TestLanguageFactory : AbstractBaseNodeFactory, ITestLanguageFactory
 			return NewDataTypeTestConcept(id);
 		if (_language.LinkTestConcept.EqualsIdentity(classifier))
 			return NewLinkTestConcept(id);
+		if (_language.RestrictedTestAnnotation.EqualsIdentity(classifier))
+			return NewRestrictedTestAnnotation(id);
 		if (_language.TestAnnotation.EqualsIdentity(classifier))
 			return NewTestAnnotation(id);
 		if (_language.TestPartition.EqualsIdentity(classifier))
@@ -226,6 +238,8 @@ public class TestLanguageFactory : AbstractBaseNodeFactory, ITestLanguageFactory
 	public virtual DataTypeTestConcept CreateDataTypeTestConcept() => NewDataTypeTestConcept(GetNewId());
 	public virtual LinkTestConcept NewLinkTestConcept(string id) => new(id);
 	public virtual LinkTestConcept CreateLinkTestConcept() => NewLinkTestConcept(GetNewId());
+	public virtual RestrictedTestAnnotation NewRestrictedTestAnnotation(string id) => new(id);
+	public virtual RestrictedTestAnnotation CreateRestrictedTestAnnotation() => NewRestrictedTestAnnotation(GetNewId());
 	public virtual TestAnnotation NewTestAnnotation(string id) => new(id);
 	public virtual TestAnnotation CreateTestAnnotation() => NewTestAnnotation(GetNewId());
 	public virtual TestPartition NewTestPartition(string id) => new(id);
@@ -909,6 +923,34 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 		return this;
 	}
 
+	private LinkTestConcept? _otherContainment_0_1 = null;
+	/// <remarks>Optional Single Containment</remarks>
+        [LionCoreMetaPointer(Language = typeof(TestLanguageLanguage), Key = "LinkTestConcept-otherContainment_0_1")]
+	[LionCoreFeature(Kind = LionCoreFeatureKind.Containment, Optional = true, Multiple = false)]
+	public LinkTestConcept? OtherContainment_0_1 { get => _otherContainment_0_1; set => SetOtherContainment_0_1(value); }
+
+	/// <remarks>Optional Single Containment</remarks>
+        public bool TryGetOtherContainment_0_1([NotNullWhenAttribute(true)] out LinkTestConcept? otherContainment_0_1)
+	{
+		otherContainment_0_1 = _otherContainment_0_1;
+		return otherContainment_0_1 != null;
+	}
+
+	private bool SetOtherContainment_0_1Raw(LinkTestConcept? value)
+	{
+		if (!ExchangeChildRaw(value, _otherContainment_0_1))
+			return false;
+		_otherContainment_0_1 = value;
+		return true;
+	}
+
+	/// <remarks>Optional Single Containment</remarks>
+        public LinkTestConcept SetOtherContainment_0_1(LinkTestConcept? value)
+	{
+		SetOptionalSingleContainment<LinkTestConcept>(value, TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1, _otherContainment_0_1, SetOtherContainment_0_1Raw);
+		return this;
+	}
+
 	private ReferenceTarget? _reference_0_1 = null;
 	/// <remarks>Optional Single Reference</remarks>
         [LionCoreMetaPointer(Language = typeof(TestLanguageLanguage), Key = "LinkTestConcept-reference_0_1")]
@@ -1094,6 +1136,12 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 			return true;
 		}
 
+		if (TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1.EqualsIdentity(feature))
+		{
+			result = OtherContainment_0_1;
+			return true;
+		}
+
 		if (TestLanguageLanguage.Instance.LinkTestConcept_reference_0_1.EqualsIdentity(feature))
 		{
 			result = Reference_0_1;
@@ -1147,6 +1195,12 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 		if (TestLanguageLanguage.Instance.LinkTestConcept_containment_1.EqualsIdentity(feature))
 		{
 			result = _containment_1;
+			return true;
+		}
+
+		if (TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1.EqualsIdentity(feature))
+		{
+			result = _otherContainment_0_1;
 			return true;
 		}
 
@@ -1260,6 +1314,17 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 			return true;
 		}
 
+		if (TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1.EqualsIdentity(feature))
+		{
+			if (value is null or LionWeb.Integration.Languages.Generated.V2023_1.TestLanguage.M2.LinkTestConcept)
+			{
+				SetOtherContainment_0_1((LionWeb.Integration.Languages.Generated.V2023_1.TestLanguage.M2.LinkTestConcept?)value);
+				return true;
+			}
+
+			throw new InvalidValueException(feature, value);
+		}
+
 		if (TestLanguageLanguage.Instance.LinkTestConcept_reference_0_1.EqualsIdentity(feature))
 		{
 			if (value is null or LionWeb.Integration.Languages.Generated.V2023_1.TestLanguage.M2.LinkTestConcept)
@@ -1326,6 +1391,8 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 			return SetContainment_0_1Raw((LionWeb.Integration.Languages.Generated.V2023_1.TestLanguage.M2.LinkTestConcept?)value);
 		if (TestLanguageLanguage.Instance.LinkTestConcept_containment_1.EqualsIdentity(feature) && value is null or LionWeb.Integration.Languages.Generated.V2023_1.TestLanguage.M2.LinkTestConcept)
 			return SetContainment_1Raw((LionWeb.Integration.Languages.Generated.V2023_1.TestLanguage.M2.LinkTestConcept?)value);
+		if (TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1.EqualsIdentity(feature) && value is null or LionWeb.Integration.Languages.Generated.V2023_1.TestLanguage.M2.LinkTestConcept)
+			return SetOtherContainment_0_1Raw((LionWeb.Integration.Languages.Generated.V2023_1.TestLanguage.M2.LinkTestConcept?)value);
 		return false;
 	}
 
@@ -1354,6 +1421,8 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 			result.Add(TestLanguageLanguage.Instance.LinkTestConcept_containment_1);
 		if (TryGetContainment_1_n(out _))
 			result.Add(TestLanguageLanguage.Instance.LinkTestConcept_containment_1_n);
+		if (TryGetOtherContainment_0_1(out _))
+			result.Add(TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1);
 		if (TryGetReference_0_1(out _))
 			result.Add(TestLanguageLanguage.Instance.LinkTestConcept_reference_0_1);
 		if (TryGetReference_0_n(out _))
@@ -1561,6 +1630,14 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 			return true;
 		}
 
+		if (TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1.EqualsIdentity(c))
+		{
+			_otherContainment_0_1 = null;
+			if (notify)
+				NotifyRemoveFromParent<LinkTestConcept>(child, TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1);
+			return true;
+		}
+
 		return false;
 	}
 
@@ -1578,7 +1655,117 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 			return TestLanguageLanguage.Instance.LinkTestConcept_containment_1;
 		if (child is LinkTestConcept child3 && (_containment_1_n?.Contains(child3) ?? false))
 			return TestLanguageLanguage.Instance.LinkTestConcept_containment_1_n;
+		if (ReferenceEquals(_otherContainment_0_1, child))
+			return TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1;
 		return null;
+	}
+}
+
+[LionCoreMetaPointer(Language = typeof(TestLanguageLanguage), Key = "RestrictedTestAnnotation")]
+public partial class RestrictedTestAnnotation : AnnotationInstanceBase, INamedWritable
+{
+	private string? _name = null;
+	private bool SetNameRaw(string? value)
+	{
+		if (value == _name)
+			return false;
+		_name = value;
+		return true;
+	}
+
+	/// <remarks>Required Property</remarks>
+    	/// <exception cref = "UnsetFeatureException">If Name has not been set</exception>
+    	/// <exception cref = "InvalidValueException">If set to null</exception>
+        [LionCoreMetaPointer(Language = typeof(LionWeb.Core.VersionSpecific.V2023_1.BuiltInsLanguage_2023_1), Key = "LionCore-builtins-INamed-name")]
+	[LionCoreFeature(Kind = LionCoreFeatureKind.Property, Optional = false, Multiple = false)]
+	public string Name { get => _name ?? throw new UnsetFeatureException(_builtIns.INamed_name); set => SetName(value); }
+
+	/// <remarks>Required Property</remarks>
+    	/// <exception cref = "InvalidValueException">If set to null</exception>
+        public bool TryGetName([NotNullWhenAttribute(true)] out string? name)
+	{
+		name = _name;
+		return name != null;
+	}
+/// <remarks>Required Property</remarks>
+/// <exception cref="InvalidValueException">If set to null</exception>
+ INamedWritable INamedWritable.SetName(string value) => SetName(value);
+	/// <remarks>Required Property</remarks>
+    	/// <exception cref = "InvalidValueException">If set to null</exception>
+        public RestrictedTestAnnotation SetName(string value)
+	{
+		SetRequiredReferenceTypeProperty<string>(value, _builtIns.INamed_name, _name, SetNameRaw);
+		return this;
+	}
+
+	public RestrictedTestAnnotation(string id) : base(id)
+	{
+	}
+
+	/// <inheritdoc/>
+        public override Annotation GetAnnotation() => TestLanguageLanguage.Instance.RestrictedTestAnnotation;
+	/// <inheritdoc/>
+        protected override bool GetInternal(Feature? feature, out object? result)
+	{
+		if (base.GetInternal(feature, out result))
+			return true;
+		if (_builtIns.INamed_name.EqualsIdentity(feature))
+		{
+			result = Name;
+			return true;
+		}
+
+		return false;
+	}
+
+	protected override bool TryGetPropertyRaw(Property feature, out object? result)
+	{
+		if (base.TryGetPropertyRaw(feature, out result))
+			return true;
+		if (_builtIns.INamed_name.EqualsIdentity(feature))
+		{
+			result = _name;
+			return true;
+		}
+
+		return false;
+	}
+
+	/// <inheritdoc/>
+        protected override bool SetInternal(Feature? feature, object? value)
+	{
+		if (base.SetInternal(feature, value))
+			return true;
+		if (_builtIns.INamed_name.EqualsIdentity(feature))
+		{
+			if (value is string v)
+			{
+				SetName(v);
+				return true;
+			}
+
+			throw new InvalidValueException(feature, value);
+		}
+
+		return false;
+	}
+
+	protected override bool SetPropertyRaw(Property feature, object? value)
+	{
+		if (base.SetPropertyRaw(feature, value))
+			return true;
+		if (_builtIns.INamed_name.EqualsIdentity(feature) && value is null or string)
+			return SetNameRaw((string?)value);
+		return false;
+	}
+
+	/// <inheritdoc/>
+        public override IEnumerable<Feature> CollectAllSetFeatures()
+	{
+		List<Feature> result = base.CollectAllSetFeatures().ToList();
+		if (TryGetName(out _))
+			result.Add(_builtIns.INamed_name);
+		return result;
 	}
 }
 

--- a/cs/LionWeb.Integration.Languages/Generated/V2024_1/TestLanguage.g.cs
+++ b/cs/LionWeb.Integration.Languages/Generated/V2024_1/TestLanguage.g.cs
@@ -32,15 +32,17 @@ public partial class TestLanguageLanguage : LanguageBase<ITestLanguageFactory>
 		_dataTypeTestConcept_integerValue_1 = new(() => new PropertyBase<TestLanguageLanguage>("DataTypeTestConcept-integerValue_1", DataTypeTestConcept, this) { Key = "DataTypeTestConcept-integerValue_1", Name = "integerValue_1", Optional = false, Type = _builtIns.Integer });
 		_dataTypeTestConcept_stringValue_0_1 = new(() => new PropertyBase<TestLanguageLanguage>("DataTypeTestConcept-stringValue_0_1", DataTypeTestConcept, this) { Key = "DataTypeTestConcept-stringValue_0_1", Name = "stringValue_0_1", Optional = true, Type = _builtIns.String });
 		_dataTypeTestConcept_stringValue_1 = new(() => new PropertyBase<TestLanguageLanguage>("DataTypeTestConcept-stringValue_1", DataTypeTestConcept, this) { Key = "DataTypeTestConcept-stringValue_1", Name = "stringValue_1", Optional = false, Type = _builtIns.String });
-		_linkTestConcept = new(() => new ConceptBase<TestLanguageLanguage>("LinkTestConcept", this) { Key = "LinkTestConcept", Name = "LinkTestConcept", Abstract = false, Partition = false, ImplementsLazy = new(() => [_builtIns.INamed]), FeaturesLazy = new(() => [LinkTestConcept_containment_0_1, LinkTestConcept_containment_0_n, LinkTestConcept_containment_1, LinkTestConcept_containment_1_n, LinkTestConcept_reference_0_1, LinkTestConcept_reference_0_n, LinkTestConcept_reference_1, LinkTestConcept_reference_1_n]) });
+		_linkTestConcept = new(() => new ConceptBase<TestLanguageLanguage>("LinkTestConcept", this) { Key = "LinkTestConcept", Name = "LinkTestConcept", Abstract = false, Partition = false, ImplementsLazy = new(() => [_builtIns.INamed]), FeaturesLazy = new(() => [LinkTestConcept_containment_0_1, LinkTestConcept_containment_0_n, LinkTestConcept_containment_1, LinkTestConcept_containment_1_n, LinkTestConcept_otherContainment_0_1, LinkTestConcept_reference_0_1, LinkTestConcept_reference_0_n, LinkTestConcept_reference_1, LinkTestConcept_reference_1_n]) });
 		_linkTestConcept_containment_0_1 = new(() => new ContainmentBase<TestLanguageLanguage>("LinkTestConcept-containment_0_1", LinkTestConcept, this) { Key = "LinkTestConcept-containment_0_1", Name = "containment_0_1", Optional = true, Multiple = false, Type = LinkTestConcept });
 		_linkTestConcept_containment_0_n = new(() => new ContainmentBase<TestLanguageLanguage>("LinkTestConcept-containment_0_n", LinkTestConcept, this) { Key = "LinkTestConcept-containment_0_n", Name = "containment_0_n", Optional = true, Multiple = true, Type = LinkTestConcept });
 		_linkTestConcept_containment_1 = new(() => new ContainmentBase<TestLanguageLanguage>("LinkTestConcept-containment_1", LinkTestConcept, this) { Key = "LinkTestConcept-containment_1", Name = "containment_1", Optional = false, Multiple = false, Type = LinkTestConcept });
 		_linkTestConcept_containment_1_n = new(() => new ContainmentBase<TestLanguageLanguage>("LinkTestConcept-containment_1_n", LinkTestConcept, this) { Key = "LinkTestConcept-containment_1_n", Name = "containment_1_n", Optional = false, Multiple = true, Type = LinkTestConcept });
+		_linkTestConcept_otherContainment_0_1 = new(() => new ContainmentBase<TestLanguageLanguage>("LinkTestConcept-otherContainment_0_1", LinkTestConcept, this) { Key = "LinkTestConcept-otherContainment_0_1", Name = "otherContainment_0_1", Optional = true, Multiple = false, Type = LinkTestConcept });
 		_linkTestConcept_reference_0_1 = new(() => new ReferenceBase<TestLanguageLanguage>("LinkTestConcept-reference_0_1", LinkTestConcept, this) { Key = "LinkTestConcept-reference_0_1", Name = "reference_0_1", Optional = true, Multiple = false, Type = LinkTestConcept });
 		_linkTestConcept_reference_0_n = new(() => new ReferenceBase<TestLanguageLanguage>("LinkTestConcept-reference_0_n", LinkTestConcept, this) { Key = "LinkTestConcept-reference_0_n", Name = "reference_0_n", Optional = true, Multiple = true, Type = LinkTestConcept });
 		_linkTestConcept_reference_1 = new(() => new ReferenceBase<TestLanguageLanguage>("LinkTestConcept-reference_1", LinkTestConcept, this) { Key = "LinkTestConcept-reference_1", Name = "reference_1", Optional = false, Multiple = false, Type = LinkTestConcept });
 		_linkTestConcept_reference_1_n = new(() => new ReferenceBase<TestLanguageLanguage>("LinkTestConcept-reference_1_n", LinkTestConcept, this) { Key = "LinkTestConcept-reference_1_n", Name = "reference_1_n", Optional = false, Multiple = true, Type = LinkTestConcept });
+		_restrictedTestAnnotation = new(() => new AnnotationBase<TestLanguageLanguage>("RestrictedTestAnnotation", this) { Key = "RestrictedTestAnnotation", Name = "RestrictedTestAnnotation", AnnotatesLazy = new(() => LinkTestConcept), ImplementsLazy = new(() => [_builtIns.INamed]) });
 		_secondTestEnumeration = new(() => new EnumerationBase<TestLanguageLanguage>("SecondTestEnumeration", this) { Key = "SecondTestEnumeration", Name = "SecondTestEnumeration", LiteralsLazy = new(() => [SecondTestEnumeration_literal1, SecondTestEnumeration_literal2, SecondTestEnumeration_literal3]) });
 		_secondTestEnumeration_literal1 = new(() => new EnumerationLiteralBase<TestLanguageLanguage>("SecondTestEnumeration-literal1", SecondTestEnumeration, this) { Key = "SecondTestEnumeration-literal1", Name = "literal1" });
 		_secondTestEnumeration_literal2 = new(() => new EnumerationLiteralBase<TestLanguageLanguage>("SecondTestEnumeration-literal2", SecondTestEnumeration, this) { Key = "SecondTestEnumeration-literal2", Name = "literal2" });
@@ -59,7 +61,7 @@ public partial class TestLanguageLanguage : LanguageBase<ITestLanguageFactory>
 	}
 
 	/// <inheritdoc/>
-        public override IReadOnlyList<LanguageEntity> Entities => [DataTypeTestConcept, LinkTestConcept, SecondTestEnumeration, TestAnnotation, TestEnumeration, TestPartition];
+        public override IReadOnlyList<LanguageEntity> Entities => [DataTypeTestConcept, LinkTestConcept, RestrictedTestAnnotation, SecondTestEnumeration, TestAnnotation, TestEnumeration, TestPartition];
 	/// <inheritdoc/>
         public override IReadOnlyList<Language> DependsOn => [];
 
@@ -117,6 +119,9 @@ public partial class TestLanguageLanguage : LanguageBase<ITestLanguageFactory>
 	private readonly Lazy<Containment> _linkTestConcept_containment_1_n;
 	public Containment LinkTestConcept_containment_1_n => _linkTestConcept_containment_1_n.Value;
 
+	private readonly Lazy<Containment> _linkTestConcept_otherContainment_0_1;
+	public Containment LinkTestConcept_otherContainment_0_1 => _linkTestConcept_otherContainment_0_1.Value;
+
 	private readonly Lazy<Reference> _linkTestConcept_reference_0_1;
 	public Reference LinkTestConcept_reference_0_1 => _linkTestConcept_reference_0_1.Value;
 
@@ -128,6 +133,9 @@ public partial class TestLanguageLanguage : LanguageBase<ITestLanguageFactory>
 
 	private readonly Lazy<Reference> _linkTestConcept_reference_1_n;
 	public Reference LinkTestConcept_reference_1_n => _linkTestConcept_reference_1_n.Value;
+
+	private readonly Lazy<Annotation> _restrictedTestAnnotation;
+	public Annotation RestrictedTestAnnotation => _restrictedTestAnnotation.Value;
 
 	private readonly Lazy<Enumeration> _secondTestEnumeration;
 	public Enumeration SecondTestEnumeration => _secondTestEnumeration.Value;
@@ -178,6 +186,8 @@ public partial interface ITestLanguageFactory : INodeFactory
 	public DataTypeTestConcept CreateDataTypeTestConcept();
 	public LinkTestConcept NewLinkTestConcept(string id);
 	public LinkTestConcept CreateLinkTestConcept();
+	public RestrictedTestAnnotation NewRestrictedTestAnnotation(string id);
+	public RestrictedTestAnnotation CreateRestrictedTestAnnotation();
 	public TestAnnotation NewTestAnnotation(string id);
 	public TestAnnotation CreateTestAnnotation();
 	public TestPartition NewTestPartition(string id);
@@ -199,6 +209,8 @@ public class TestLanguageFactory : AbstractBaseNodeFactory, ITestLanguageFactory
 			return NewDataTypeTestConcept(id);
 		if (_language.LinkTestConcept.EqualsIdentity(classifier))
 			return NewLinkTestConcept(id);
+		if (_language.RestrictedTestAnnotation.EqualsIdentity(classifier))
+			return NewRestrictedTestAnnotation(id);
 		if (_language.TestAnnotation.EqualsIdentity(classifier))
 			return NewTestAnnotation(id);
 		if (_language.TestPartition.EqualsIdentity(classifier))
@@ -226,6 +238,8 @@ public class TestLanguageFactory : AbstractBaseNodeFactory, ITestLanguageFactory
 	public virtual DataTypeTestConcept CreateDataTypeTestConcept() => NewDataTypeTestConcept(GetNewId());
 	public virtual LinkTestConcept NewLinkTestConcept(string id) => new(id);
 	public virtual LinkTestConcept CreateLinkTestConcept() => NewLinkTestConcept(GetNewId());
+	public virtual RestrictedTestAnnotation NewRestrictedTestAnnotation(string id) => new(id);
+	public virtual RestrictedTestAnnotation CreateRestrictedTestAnnotation() => NewRestrictedTestAnnotation(GetNewId());
 	public virtual TestAnnotation NewTestAnnotation(string id) => new(id);
 	public virtual TestAnnotation CreateTestAnnotation() => NewTestAnnotation(GetNewId());
 	public virtual TestPartition NewTestPartition(string id) => new(id);
@@ -909,6 +923,34 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 		return this;
 	}
 
+	private LinkTestConcept? _otherContainment_0_1 = null;
+	/// <remarks>Optional Single Containment</remarks>
+        [LionCoreMetaPointer(Language = typeof(TestLanguageLanguage), Key = "LinkTestConcept-otherContainment_0_1")]
+	[LionCoreFeature(Kind = LionCoreFeatureKind.Containment, Optional = true, Multiple = false)]
+	public LinkTestConcept? OtherContainment_0_1 { get => _otherContainment_0_1; set => SetOtherContainment_0_1(value); }
+
+	/// <remarks>Optional Single Containment</remarks>
+        public bool TryGetOtherContainment_0_1([NotNullWhenAttribute(true)] out LinkTestConcept? otherContainment_0_1)
+	{
+		otherContainment_0_1 = _otherContainment_0_1;
+		return otherContainment_0_1 != null;
+	}
+
+	private bool SetOtherContainment_0_1Raw(LinkTestConcept? value)
+	{
+		if (!ExchangeChildRaw(value, _otherContainment_0_1))
+			return false;
+		_otherContainment_0_1 = value;
+		return true;
+	}
+
+	/// <remarks>Optional Single Containment</remarks>
+        public LinkTestConcept SetOtherContainment_0_1(LinkTestConcept? value)
+	{
+		SetOptionalSingleContainment<LinkTestConcept>(value, TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1, _otherContainment_0_1, SetOtherContainment_0_1Raw);
+		return this;
+	}
+
 	private ReferenceTarget? _reference_0_1 = null;
 	/// <remarks>Optional Single Reference</remarks>
         [LionCoreMetaPointer(Language = typeof(TestLanguageLanguage), Key = "LinkTestConcept-reference_0_1")]
@@ -1094,6 +1136,12 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 			return true;
 		}
 
+		if (TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1.EqualsIdentity(feature))
+		{
+			result = OtherContainment_0_1;
+			return true;
+		}
+
 		if (TestLanguageLanguage.Instance.LinkTestConcept_reference_0_1.EqualsIdentity(feature))
 		{
 			result = Reference_0_1;
@@ -1147,6 +1195,12 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 		if (TestLanguageLanguage.Instance.LinkTestConcept_containment_1.EqualsIdentity(feature))
 		{
 			result = _containment_1;
+			return true;
+		}
+
+		if (TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1.EqualsIdentity(feature))
+		{
+			result = _otherContainment_0_1;
 			return true;
 		}
 
@@ -1260,6 +1314,17 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 			return true;
 		}
 
+		if (TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1.EqualsIdentity(feature))
+		{
+			if (value is null or LionWeb.Integration.Languages.Generated.V2024_1.TestLanguage.M2.LinkTestConcept)
+			{
+				SetOtherContainment_0_1((LionWeb.Integration.Languages.Generated.V2024_1.TestLanguage.M2.LinkTestConcept?)value);
+				return true;
+			}
+
+			throw new InvalidValueException(feature, value);
+		}
+
 		if (TestLanguageLanguage.Instance.LinkTestConcept_reference_0_1.EqualsIdentity(feature))
 		{
 			if (value is null or LionWeb.Integration.Languages.Generated.V2024_1.TestLanguage.M2.LinkTestConcept)
@@ -1326,6 +1391,8 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 			return SetContainment_0_1Raw((LionWeb.Integration.Languages.Generated.V2024_1.TestLanguage.M2.LinkTestConcept?)value);
 		if (TestLanguageLanguage.Instance.LinkTestConcept_containment_1.EqualsIdentity(feature) && value is null or LionWeb.Integration.Languages.Generated.V2024_1.TestLanguage.M2.LinkTestConcept)
 			return SetContainment_1Raw((LionWeb.Integration.Languages.Generated.V2024_1.TestLanguage.M2.LinkTestConcept?)value);
+		if (TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1.EqualsIdentity(feature) && value is null or LionWeb.Integration.Languages.Generated.V2024_1.TestLanguage.M2.LinkTestConcept)
+			return SetOtherContainment_0_1Raw((LionWeb.Integration.Languages.Generated.V2024_1.TestLanguage.M2.LinkTestConcept?)value);
 		return false;
 	}
 
@@ -1354,6 +1421,8 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 			result.Add(TestLanguageLanguage.Instance.LinkTestConcept_containment_1);
 		if (TryGetContainment_1_n(out _))
 			result.Add(TestLanguageLanguage.Instance.LinkTestConcept_containment_1_n);
+		if (TryGetOtherContainment_0_1(out _))
+			result.Add(TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1);
 		if (TryGetReference_0_1(out _))
 			result.Add(TestLanguageLanguage.Instance.LinkTestConcept_reference_0_1);
 		if (TryGetReference_0_n(out _))
@@ -1561,6 +1630,14 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 			return true;
 		}
 
+		if (TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1.EqualsIdentity(c))
+		{
+			_otherContainment_0_1 = null;
+			if (notify)
+				NotifyRemoveFromParent<LinkTestConcept>(child, TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1);
+			return true;
+		}
+
 		return false;
 	}
 
@@ -1578,7 +1655,117 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 			return TestLanguageLanguage.Instance.LinkTestConcept_containment_1;
 		if (child is LinkTestConcept child3 && (_containment_1_n?.Contains(child3) ?? false))
 			return TestLanguageLanguage.Instance.LinkTestConcept_containment_1_n;
+		if (ReferenceEquals(_otherContainment_0_1, child))
+			return TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1;
 		return null;
+	}
+}
+
+[LionCoreMetaPointer(Language = typeof(TestLanguageLanguage), Key = "RestrictedTestAnnotation")]
+public partial class RestrictedTestAnnotation : AnnotationInstanceBase, INamedWritable
+{
+	private string? _name = null;
+	private bool SetNameRaw(string? value)
+	{
+		if (value == _name)
+			return false;
+		_name = value;
+		return true;
+	}
+
+	/// <remarks>Required Property</remarks>
+    	/// <exception cref = "UnsetFeatureException">If Name has not been set</exception>
+    	/// <exception cref = "InvalidValueException">If set to null</exception>
+        [LionCoreMetaPointer(Language = typeof(LionWeb.Core.VersionSpecific.V2024_1.BuiltInsLanguage_2024_1), Key = "LionCore-builtins-INamed-name")]
+	[LionCoreFeature(Kind = LionCoreFeatureKind.Property, Optional = false, Multiple = false)]
+	public string Name { get => _name ?? throw new UnsetFeatureException(_builtIns.INamed_name); set => SetName(value); }
+
+	/// <remarks>Required Property</remarks>
+    	/// <exception cref = "InvalidValueException">If set to null</exception>
+        public bool TryGetName([NotNullWhenAttribute(true)] out string? name)
+	{
+		name = _name;
+		return name != null;
+	}
+/// <remarks>Required Property</remarks>
+/// <exception cref="InvalidValueException">If set to null</exception>
+ INamedWritable INamedWritable.SetName(string value) => SetName(value);
+	/// <remarks>Required Property</remarks>
+    	/// <exception cref = "InvalidValueException">If set to null</exception>
+        public RestrictedTestAnnotation SetName(string value)
+	{
+		SetRequiredReferenceTypeProperty<string>(value, _builtIns.INamed_name, _name, SetNameRaw);
+		return this;
+	}
+
+	public RestrictedTestAnnotation(string id) : base(id)
+	{
+	}
+
+	/// <inheritdoc/>
+        public override Annotation GetAnnotation() => TestLanguageLanguage.Instance.RestrictedTestAnnotation;
+	/// <inheritdoc/>
+        protected override bool GetInternal(Feature? feature, out object? result)
+	{
+		if (base.GetInternal(feature, out result))
+			return true;
+		if (_builtIns.INamed_name.EqualsIdentity(feature))
+		{
+			result = Name;
+			return true;
+		}
+
+		return false;
+	}
+
+	protected override bool TryGetPropertyRaw(Property feature, out object? result)
+	{
+		if (base.TryGetPropertyRaw(feature, out result))
+			return true;
+		if (_builtIns.INamed_name.EqualsIdentity(feature))
+		{
+			result = _name;
+			return true;
+		}
+
+		return false;
+	}
+
+	/// <inheritdoc/>
+        protected override bool SetInternal(Feature? feature, object? value)
+	{
+		if (base.SetInternal(feature, value))
+			return true;
+		if (_builtIns.INamed_name.EqualsIdentity(feature))
+		{
+			if (value is string v)
+			{
+				SetName(v);
+				return true;
+			}
+
+			throw new InvalidValueException(feature, value);
+		}
+
+		return false;
+	}
+
+	protected override bool SetPropertyRaw(Property feature, object? value)
+	{
+		if (base.SetPropertyRaw(feature, value))
+			return true;
+		if (_builtIns.INamed_name.EqualsIdentity(feature) && value is null or string)
+			return SetNameRaw((string?)value);
+		return false;
+	}
+
+	/// <inheritdoc/>
+        public override IEnumerable<Feature> CollectAllSetFeatures()
+	{
+		List<Feature> result = base.CollectAllSetFeatures().ToList();
+		if (TryGetName(out _))
+			result.Add(_builtIns.INamed_name);
+		return result;
 	}
 }
 

--- a/cs/LionWeb.Integration.Languages/Generated/V2026_1/TestLanguage.g.cs
+++ b/cs/LionWeb.Integration.Languages/Generated/V2026_1/TestLanguage.g.cs
@@ -32,15 +32,17 @@ public partial class TestLanguageLanguage : LanguageBase<ITestLanguageFactory>
 		_dataTypeTestConcept_integerValue_1 = new(() => new PropertyBase<TestLanguageLanguage>("DataTypeTestConcept-integerValue_1", DataTypeTestConcept, this) { Key = "DataTypeTestConcept-integerValue_1", Name = "integerValue_1", Optional = false, Type = _builtIns.Integer });
 		_dataTypeTestConcept_stringValue_0_1 = new(() => new PropertyBase<TestLanguageLanguage>("DataTypeTestConcept-stringValue_0_1", DataTypeTestConcept, this) { Key = "DataTypeTestConcept-stringValue_0_1", Name = "stringValue_0_1", Optional = true, Type = _builtIns.String });
 		_dataTypeTestConcept_stringValue_1 = new(() => new PropertyBase<TestLanguageLanguage>("DataTypeTestConcept-stringValue_1", DataTypeTestConcept, this) { Key = "DataTypeTestConcept-stringValue_1", Name = "stringValue_1", Optional = false, Type = _builtIns.String });
-		_linkTestConcept = new(() => new ConceptBase<TestLanguageLanguage>("LinkTestConcept", this) { Key = "LinkTestConcept", Name = "LinkTestConcept", Abstract = false, Partition = false, ImplementsLazy = new(() => [_builtIns.INamed]), FeaturesLazy = new(() => [LinkTestConcept_containment_0_1, LinkTestConcept_containment_0_n, LinkTestConcept_containment_1, LinkTestConcept_containment_1_n, LinkTestConcept_reference_0_1, LinkTestConcept_reference_0_n, LinkTestConcept_reference_1, LinkTestConcept_reference_1_n]) });
+		_linkTestConcept = new(() => new ConceptBase<TestLanguageLanguage>("LinkTestConcept", this) { Key = "LinkTestConcept", Name = "LinkTestConcept", Abstract = false, Partition = false, ImplementsLazy = new(() => [_builtIns.INamed]), FeaturesLazy = new(() => [LinkTestConcept_containment_0_1, LinkTestConcept_containment_0_n, LinkTestConcept_containment_1, LinkTestConcept_containment_1_n, LinkTestConcept_otherContainment_0_1, LinkTestConcept_reference_0_1, LinkTestConcept_reference_0_n, LinkTestConcept_reference_1, LinkTestConcept_reference_1_n]) });
 		_linkTestConcept_containment_0_1 = new(() => new ContainmentBase<TestLanguageLanguage>("LinkTestConcept-containment_0_1", LinkTestConcept, this) { Key = "LinkTestConcept-containment_0_1", Name = "containment_0_1", Optional = true, Multiple = false, Type = LinkTestConcept });
 		_linkTestConcept_containment_0_n = new(() => new ContainmentBase<TestLanguageLanguage>("LinkTestConcept-containment_0_n", LinkTestConcept, this) { Key = "LinkTestConcept-containment_0_n", Name = "containment_0_n", Optional = true, Multiple = true, Type = LinkTestConcept });
 		_linkTestConcept_containment_1 = new(() => new ContainmentBase<TestLanguageLanguage>("LinkTestConcept-containment_1", LinkTestConcept, this) { Key = "LinkTestConcept-containment_1", Name = "containment_1", Optional = false, Multiple = false, Type = LinkTestConcept });
 		_linkTestConcept_containment_1_n = new(() => new ContainmentBase<TestLanguageLanguage>("LinkTestConcept-containment_1_n", LinkTestConcept, this) { Key = "LinkTestConcept-containment_1_n", Name = "containment_1_n", Optional = false, Multiple = true, Type = LinkTestConcept });
+		_linkTestConcept_otherContainment_0_1 = new(() => new ContainmentBase<TestLanguageLanguage>("LinkTestConcept-otherContainment_0_1", LinkTestConcept, this) { Key = "LinkTestConcept-otherContainment_0_1", Name = "otherContainment_0_1", Optional = true, Multiple = false, Type = LinkTestConcept });
 		_linkTestConcept_reference_0_1 = new(() => new ReferenceBase<TestLanguageLanguage>("LinkTestConcept-reference_0_1", LinkTestConcept, this) { Key = "LinkTestConcept-reference_0_1", Name = "reference_0_1", Optional = true, Multiple = false, Type = LinkTestConcept });
 		_linkTestConcept_reference_0_n = new(() => new ReferenceBase<TestLanguageLanguage>("LinkTestConcept-reference_0_n", LinkTestConcept, this) { Key = "LinkTestConcept-reference_0_n", Name = "reference_0_n", Optional = true, Multiple = true, Type = LinkTestConcept });
 		_linkTestConcept_reference_1 = new(() => new ReferenceBase<TestLanguageLanguage>("LinkTestConcept-reference_1", LinkTestConcept, this) { Key = "LinkTestConcept-reference_1", Name = "reference_1", Optional = false, Multiple = false, Type = LinkTestConcept });
 		_linkTestConcept_reference_1_n = new(() => new ReferenceBase<TestLanguageLanguage>("LinkTestConcept-reference_1_n", LinkTestConcept, this) { Key = "LinkTestConcept-reference_1_n", Name = "reference_1_n", Optional = false, Multiple = true, Type = LinkTestConcept });
+		_restrictedTestAnnotation = new(() => new AnnotationBase<TestLanguageLanguage>("RestrictedTestAnnotation", this) { Key = "RestrictedTestAnnotation", Name = "RestrictedTestAnnotation", AnnotatesLazy = new(() => LinkTestConcept), ImplementsLazy = new(() => [_builtIns.INamed]) });
 		_secondTestEnumeration = new(() => new EnumerationBase<TestLanguageLanguage>("SecondTestEnumeration", this) { Key = "SecondTestEnumeration", Name = "SecondTestEnumeration", LiteralsLazy = new(() => [SecondTestEnumeration_literal1, SecondTestEnumeration_literal2, SecondTestEnumeration_literal3]) });
 		_secondTestEnumeration_literal1 = new(() => new EnumerationLiteralBase<TestLanguageLanguage>("SecondTestEnumeration-literal1", SecondTestEnumeration, this) { Key = "SecondTestEnumeration-literal1", Name = "literal1" });
 		_secondTestEnumeration_literal2 = new(() => new EnumerationLiteralBase<TestLanguageLanguage>("SecondTestEnumeration-literal2", SecondTestEnumeration, this) { Key = "SecondTestEnumeration-literal2", Name = "literal2" });
@@ -59,7 +61,7 @@ public partial class TestLanguageLanguage : LanguageBase<ITestLanguageFactory>
 	}
 
 	/// <inheritdoc/>
-        public override IReadOnlyList<LanguageEntity> Entities => [DataTypeTestConcept, LinkTestConcept, SecondTestEnumeration, TestAnnotation, TestEnumeration, TestPartition];
+        public override IReadOnlyList<LanguageEntity> Entities => [DataTypeTestConcept, LinkTestConcept, RestrictedTestAnnotation, SecondTestEnumeration, TestAnnotation, TestEnumeration, TestPartition];
 	/// <inheritdoc/>
         public override IReadOnlyList<Language> DependsOn => [];
 
@@ -117,6 +119,9 @@ public partial class TestLanguageLanguage : LanguageBase<ITestLanguageFactory>
 	private readonly Lazy<Containment> _linkTestConcept_containment_1_n;
 	public Containment LinkTestConcept_containment_1_n => _linkTestConcept_containment_1_n.Value;
 
+	private readonly Lazy<Containment> _linkTestConcept_otherContainment_0_1;
+	public Containment LinkTestConcept_otherContainment_0_1 => _linkTestConcept_otherContainment_0_1.Value;
+
 	private readonly Lazy<Reference> _linkTestConcept_reference_0_1;
 	public Reference LinkTestConcept_reference_0_1 => _linkTestConcept_reference_0_1.Value;
 
@@ -128,6 +133,9 @@ public partial class TestLanguageLanguage : LanguageBase<ITestLanguageFactory>
 
 	private readonly Lazy<Reference> _linkTestConcept_reference_1_n;
 	public Reference LinkTestConcept_reference_1_n => _linkTestConcept_reference_1_n.Value;
+
+	private readonly Lazy<Annotation> _restrictedTestAnnotation;
+	public Annotation RestrictedTestAnnotation => _restrictedTestAnnotation.Value;
 
 	private readonly Lazy<Enumeration> _secondTestEnumeration;
 	public Enumeration SecondTestEnumeration => _secondTestEnumeration.Value;
@@ -178,6 +186,8 @@ public partial interface ITestLanguageFactory : INodeFactory
 	public DataTypeTestConcept CreateDataTypeTestConcept();
 	public LinkTestConcept NewLinkTestConcept(string id);
 	public LinkTestConcept CreateLinkTestConcept();
+	public RestrictedTestAnnotation NewRestrictedTestAnnotation(string id);
+	public RestrictedTestAnnotation CreateRestrictedTestAnnotation();
 	public TestAnnotation NewTestAnnotation(string id);
 	public TestAnnotation CreateTestAnnotation();
 	public TestPartition NewTestPartition(string id);
@@ -199,6 +209,8 @@ public class TestLanguageFactory : AbstractBaseNodeFactory, ITestLanguageFactory
 			return NewDataTypeTestConcept(id);
 		if (_language.LinkTestConcept.EqualsIdentity(classifier))
 			return NewLinkTestConcept(id);
+		if (_language.RestrictedTestAnnotation.EqualsIdentity(classifier))
+			return NewRestrictedTestAnnotation(id);
 		if (_language.TestAnnotation.EqualsIdentity(classifier))
 			return NewTestAnnotation(id);
 		if (_language.TestPartition.EqualsIdentity(classifier))
@@ -226,6 +238,8 @@ public class TestLanguageFactory : AbstractBaseNodeFactory, ITestLanguageFactory
 	public virtual DataTypeTestConcept CreateDataTypeTestConcept() => NewDataTypeTestConcept(GetNewId());
 	public virtual LinkTestConcept NewLinkTestConcept(string id) => new(id);
 	public virtual LinkTestConcept CreateLinkTestConcept() => NewLinkTestConcept(GetNewId());
+	public virtual RestrictedTestAnnotation NewRestrictedTestAnnotation(string id) => new(id);
+	public virtual RestrictedTestAnnotation CreateRestrictedTestAnnotation() => NewRestrictedTestAnnotation(GetNewId());
 	public virtual TestAnnotation NewTestAnnotation(string id) => new(id);
 	public virtual TestAnnotation CreateTestAnnotation() => NewTestAnnotation(GetNewId());
 	public virtual TestPartition NewTestPartition(string id) => new(id);
@@ -909,6 +923,34 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 		return this;
 	}
 
+	private LinkTestConcept? _otherContainment_0_1 = null;
+	/// <remarks>Optional Single Containment</remarks>
+        [LionCoreMetaPointer(Language = typeof(TestLanguageLanguage), Key = "LinkTestConcept-otherContainment_0_1")]
+	[LionCoreFeature(Kind = LionCoreFeatureKind.Containment, Optional = true, Multiple = false)]
+	public LinkTestConcept? OtherContainment_0_1 { get => _otherContainment_0_1; set => SetOtherContainment_0_1(value); }
+
+	/// <remarks>Optional Single Containment</remarks>
+        public bool TryGetOtherContainment_0_1([NotNullWhenAttribute(true)] out LinkTestConcept? otherContainment_0_1)
+	{
+		otherContainment_0_1 = _otherContainment_0_1;
+		return otherContainment_0_1 != null;
+	}
+
+	private bool SetOtherContainment_0_1Raw(LinkTestConcept? value)
+	{
+		if (!ExchangeChildRaw(value, _otherContainment_0_1))
+			return false;
+		_otherContainment_0_1 = value;
+		return true;
+	}
+
+	/// <remarks>Optional Single Containment</remarks>
+        public LinkTestConcept SetOtherContainment_0_1(LinkTestConcept? value)
+	{
+		SetOptionalSingleContainment<LinkTestConcept>(value, TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1, _otherContainment_0_1, SetOtherContainment_0_1Raw);
+		return this;
+	}
+
 	private ReferenceTarget? _reference_0_1 = null;
 	/// <remarks>Optional Single Reference</remarks>
         [LionCoreMetaPointer(Language = typeof(TestLanguageLanguage), Key = "LinkTestConcept-reference_0_1")]
@@ -1094,6 +1136,12 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 			return true;
 		}
 
+		if (TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1.EqualsIdentity(feature))
+		{
+			result = OtherContainment_0_1;
+			return true;
+		}
+
 		if (TestLanguageLanguage.Instance.LinkTestConcept_reference_0_1.EqualsIdentity(feature))
 		{
 			result = Reference_0_1;
@@ -1147,6 +1195,12 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 		if (TestLanguageLanguage.Instance.LinkTestConcept_containment_1.EqualsIdentity(feature))
 		{
 			result = _containment_1;
+			return true;
+		}
+
+		if (TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1.EqualsIdentity(feature))
+		{
+			result = _otherContainment_0_1;
 			return true;
 		}
 
@@ -1260,6 +1314,17 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 			return true;
 		}
 
+		if (TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1.EqualsIdentity(feature))
+		{
+			if (value is null or LionWeb.Integration.Languages.Generated.V2026_1.TestLanguage.M2.LinkTestConcept)
+			{
+				SetOtherContainment_0_1((LionWeb.Integration.Languages.Generated.V2026_1.TestLanguage.M2.LinkTestConcept?)value);
+				return true;
+			}
+
+			throw new InvalidValueException(feature, value);
+		}
+
 		if (TestLanguageLanguage.Instance.LinkTestConcept_reference_0_1.EqualsIdentity(feature))
 		{
 			if (value is null or LionWeb.Integration.Languages.Generated.V2026_1.TestLanguage.M2.LinkTestConcept)
@@ -1326,6 +1391,8 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 			return SetContainment_0_1Raw((LionWeb.Integration.Languages.Generated.V2026_1.TestLanguage.M2.LinkTestConcept?)value);
 		if (TestLanguageLanguage.Instance.LinkTestConcept_containment_1.EqualsIdentity(feature) && value is null or LionWeb.Integration.Languages.Generated.V2026_1.TestLanguage.M2.LinkTestConcept)
 			return SetContainment_1Raw((LionWeb.Integration.Languages.Generated.V2026_1.TestLanguage.M2.LinkTestConcept?)value);
+		if (TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1.EqualsIdentity(feature) && value is null or LionWeb.Integration.Languages.Generated.V2026_1.TestLanguage.M2.LinkTestConcept)
+			return SetOtherContainment_0_1Raw((LionWeb.Integration.Languages.Generated.V2026_1.TestLanguage.M2.LinkTestConcept?)value);
 		return false;
 	}
 
@@ -1354,6 +1421,8 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 			result.Add(TestLanguageLanguage.Instance.LinkTestConcept_containment_1);
 		if (TryGetContainment_1_n(out _))
 			result.Add(TestLanguageLanguage.Instance.LinkTestConcept_containment_1_n);
+		if (TryGetOtherContainment_0_1(out _))
+			result.Add(TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1);
 		if (TryGetReference_0_1(out _))
 			result.Add(TestLanguageLanguage.Instance.LinkTestConcept_reference_0_1);
 		if (TryGetReference_0_n(out _))
@@ -1561,6 +1630,14 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 			return true;
 		}
 
+		if (TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1.EqualsIdentity(c))
+		{
+			_otherContainment_0_1 = null;
+			if (notify)
+				NotifyRemoveFromParent<LinkTestConcept>(child, TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1);
+			return true;
+		}
+
 		return false;
 	}
 
@@ -1578,7 +1655,117 @@ public partial class LinkTestConcept : ConceptInstanceBase, INamedWritable
 			return TestLanguageLanguage.Instance.LinkTestConcept_containment_1;
 		if (child is LinkTestConcept child3 && (_containment_1_n?.Contains(child3) ?? false))
 			return TestLanguageLanguage.Instance.LinkTestConcept_containment_1_n;
+		if (ReferenceEquals(_otherContainment_0_1, child))
+			return TestLanguageLanguage.Instance.LinkTestConcept_otherContainment_0_1;
 		return null;
+	}
+}
+
+[LionCoreMetaPointer(Language = typeof(TestLanguageLanguage), Key = "RestrictedTestAnnotation")]
+public partial class RestrictedTestAnnotation : AnnotationInstanceBase, INamedWritable
+{
+	private string? _name = null;
+	private bool SetNameRaw(string? value)
+	{
+		if (value == _name)
+			return false;
+		_name = value;
+		return true;
+	}
+
+	/// <remarks>Required Property</remarks>
+    	/// <exception cref = "UnsetFeatureException">If Name has not been set</exception>
+    	/// <exception cref = "InvalidValueException">If set to null</exception>
+        [LionCoreMetaPointer(Language = typeof(LionWeb.Core.VersionSpecific.V2026_1.BuiltInsLanguage_2026_1), Key = "LionCore-builtins-INamed-name")]
+	[LionCoreFeature(Kind = LionCoreFeatureKind.Property, Optional = false, Multiple = false)]
+	public string Name { get => _name ?? throw new UnsetFeatureException(_builtIns.INamed_name); set => SetName(value); }
+
+	/// <remarks>Required Property</remarks>
+    	/// <exception cref = "InvalidValueException">If set to null</exception>
+        public bool TryGetName([NotNullWhenAttribute(true)] out string? name)
+	{
+		name = _name;
+		return name != null;
+	}
+/// <remarks>Required Property</remarks>
+/// <exception cref="InvalidValueException">If set to null</exception>
+ INamedWritable INamedWritable.SetName(string value) => SetName(value);
+	/// <remarks>Required Property</remarks>
+    	/// <exception cref = "InvalidValueException">If set to null</exception>
+        public RestrictedTestAnnotation SetName(string value)
+	{
+		SetRequiredReferenceTypeProperty<string>(value, _builtIns.INamed_name, _name, SetNameRaw);
+		return this;
+	}
+
+	public RestrictedTestAnnotation(string id) : base(id)
+	{
+	}
+
+	/// <inheritdoc/>
+        public override Annotation GetAnnotation() => TestLanguageLanguage.Instance.RestrictedTestAnnotation;
+	/// <inheritdoc/>
+        protected override bool GetInternal(Feature? feature, out object? result)
+	{
+		if (base.GetInternal(feature, out result))
+			return true;
+		if (_builtIns.INamed_name.EqualsIdentity(feature))
+		{
+			result = Name;
+			return true;
+		}
+
+		return false;
+	}
+
+	protected override bool TryGetPropertyRaw(Property feature, out object? result)
+	{
+		if (base.TryGetPropertyRaw(feature, out result))
+			return true;
+		if (_builtIns.INamed_name.EqualsIdentity(feature))
+		{
+			result = _name;
+			return true;
+		}
+
+		return false;
+	}
+
+	/// <inheritdoc/>
+        protected override bool SetInternal(Feature? feature, object? value)
+	{
+		if (base.SetInternal(feature, value))
+			return true;
+		if (_builtIns.INamed_name.EqualsIdentity(feature))
+		{
+			if (value is string v)
+			{
+				SetName(v);
+				return true;
+			}
+
+			throw new InvalidValueException(feature, value);
+		}
+
+		return false;
+	}
+
+	protected override bool SetPropertyRaw(Property feature, object? value)
+	{
+		if (base.SetPropertyRaw(feature, value))
+			return true;
+		if (_builtIns.INamed_name.EqualsIdentity(feature) && value is null or string)
+			return SetNameRaw((string?)value);
+		return false;
+	}
+
+	/// <inheritdoc/>
+        public override IEnumerable<Feature> CollectAllSetFeatures()
+	{
+		List<Feature> result = base.CollectAllSetFeatures().ToList();
+		if (TryGetName(out _))
+			result.Add(_builtIns.INamed_name);
+		return result;
 	}
 }
 

--- a/testLanguage/testLanguage.2023.1.json
+++ b/testLanguage/testLanguage.2023.1.json
@@ -57,6 +57,7 @@
                         "DataTypeTestConcept",
                         "LinkTestConcept",
                         "TestAnnotation",
+                        "RestrictedTestAnnotation",
                         "TestPartition"
                     ]
                 }
@@ -893,7 +894,8 @@
                         "LinkTestConcept-reference_0_1",
                         "LinkTestConcept-reference_1",
                         "LinkTestConcept-reference_0_n",
-                        "LinkTestConcept-reference_1_n"
+                        "LinkTestConcept-reference_1_n",
+                        "LinkTestConcept-otherContainment_0_1"
                     ]
                 }
             ],
@@ -1404,6 +1406,66 @@
             "parent": "LinkTestConcept"
         },
         {
+            "id": "LinkTestConcept-otherContainment_0_1",
+            "classifier": {
+                "language": "LionCore-M3",
+                "version": "2023.1",
+                "key": "Containment"
+            },
+            "properties": [
+                {
+                    "property": {
+                        "language": "LionCore-M3",
+                        "version": "2023.1",
+                        "key": "Link-multiple"
+                    },
+                    "value": "false"
+                },
+                {
+                    "property": {
+                        "language": "LionCore-M3",
+                        "version": "2023.1",
+                        "key": "Feature-optional"
+                    },
+                    "value": "true"
+                },
+                {
+                    "property": {
+                        "language": "LionCore-M3",
+                        "version": "2023.1",
+                        "key": "IKeyed-key"
+                    },
+                    "value": "LinkTestConcept-otherContainment_0_1"
+                },
+                {
+                    "property": {
+                        "language": "LionCore-builtins",
+                        "version": "2023.1",
+                        "key": "LionCore-builtins-INamed-name"
+                    },
+                    "value": "otherContainment_0_1"
+                }
+            ],
+            "containments": [],
+            "references": [
+                {
+                    "reference": {
+                        "language": "LionCore-M3",
+                        "version": "2023.1",
+                        "key": "Link-type"
+                    },
+                    "targets": [
+                        {
+                            "resolveInfo": "LinkTestConcept",
+                            "reference": "LinkTestConcept"
+                        }
+                    ]
+                }
+            ],
+            "annotations": [],
+            "parent": "LinkTestConcept"
+        },
+        {
             "id": "TestAnnotation",
             "classifier": {
                 "language": "LionCore-M3",
@@ -1599,6 +1661,80 @@
             ],
             "annotations": [],
             "parent": "TestAnnotation"
+        },
+        {
+            "id": "RestrictedTestAnnotation",
+            "classifier": {
+                "language": "LionCore-M3",
+                "version": "2023.1",
+                "key": "Annotation"
+            },
+            "properties": [
+                {
+                    "property": {
+                        "language": "LionCore-M3",
+                        "version": "2023.1",
+                        "key": "IKeyed-key"
+                    },
+                    "value": "RestrictedTestAnnotation"
+                },
+                {
+                    "property": {
+                        "language": "LionCore-builtins",
+                        "version": "2023.1",
+                        "key": "LionCore-builtins-INamed-name"
+                    },
+                    "value": "RestrictedTestAnnotation"
+                }
+            ],
+            "containments": [
+                {
+                    "containment": {
+                        "language": "LionCore-M3",
+                        "version": "2023.1",
+                        "key": "Classifier-features"
+                    },
+                    "children": []
+                }
+            ],
+            "references": [
+                {
+                    "reference": {
+                        "language": "LionCore-M3",
+                        "version": "2023.1",
+                        "key": "Annotation-annotates"
+                    },
+                    "targets": [
+                        {
+                            "resolveInfo": "LinkTestConcept",
+                            "reference": "LinkTestConcept"
+                        }
+                    ]
+                },
+                {
+                    "reference": {
+                        "language": "LionCore-M3",
+                        "version": "2023.1",
+                        "key": "Annotation-extends"
+                    },
+                    "targets": []
+                },
+                {
+                    "reference": {
+                        "language": "LionCore-M3",
+                        "version": "2023.1",
+                        "key": "Annotation-implements"
+                    },
+                    "targets": [
+                        {
+                            "resolveInfo": "INamed",
+                            "reference": "LionCore-builtins-INamed"
+                        }
+                    ]
+                }
+            ],
+            "annotations": [],
+            "parent": "TestLanguage"
         },
         {
             "id": "TestPartition",

--- a/testLanguage/testLanguage.2024.1.json
+++ b/testLanguage/testLanguage.2024.1.json
@@ -57,6 +57,7 @@
                         "DataTypeTestConcept",
                         "LinkTestConcept",
                         "TestAnnotation",
+                        "RestrictedTestAnnotation",
                         "TestPartition"
                     ]
                 }
@@ -893,7 +894,8 @@
                         "LinkTestConcept-reference_0_1",
                         "LinkTestConcept-reference_1",
                         "LinkTestConcept-reference_0_n",
-                        "LinkTestConcept-reference_1_n"
+                        "LinkTestConcept-reference_1_n",
+                        "LinkTestConcept-otherContainment_0_1"
                     ]
                 }
             ],
@@ -1404,6 +1406,66 @@
             "parent": "LinkTestConcept"
         },
         {
+            "id": "LinkTestConcept-otherContainment_0_1",
+            "classifier": {
+                "language": "LionCore-M3",
+                "version": "2024.1",
+                "key": "Containment"
+            },
+            "properties": [
+                {
+                    "property": {
+                        "language": "LionCore-M3",
+                        "version": "2024.1",
+                        "key": "Link-multiple"
+                    },
+                    "value": "false"
+                },
+                {
+                    "property": {
+                        "language": "LionCore-M3",
+                        "version": "2024.1",
+                        "key": "Feature-optional"
+                    },
+                    "value": "true"
+                },
+                {
+                    "property": {
+                        "language": "LionCore-M3",
+                        "version": "2024.1",
+                        "key": "IKeyed-key"
+                    },
+                    "value": "LinkTestConcept-otherContainment_0_1"
+                },
+                {
+                    "property": {
+                        "language": "LionCore-builtins",
+                        "version": "2024.1",
+                        "key": "LionCore-builtins-INamed-name"
+                    },
+                    "value": "otherContainment_0_1"
+                }
+            ],
+            "containments": [],
+            "references": [
+                {
+                    "reference": {
+                        "language": "LionCore-M3",
+                        "version": "2024.1",
+                        "key": "Link-type"
+                    },
+                    "targets": [
+                        {
+                            "resolveInfo": "LinkTestConcept",
+                            "reference": "LinkTestConcept"
+                        }
+                    ]
+                }
+            ],
+            "annotations": [],
+            "parent": "LinkTestConcept"
+        },
+        {
             "id": "TestAnnotation",
             "classifier": {
                 "language": "LionCore-M3",
@@ -1599,6 +1661,80 @@
             ],
             "annotations": [],
             "parent": "TestAnnotation"
+        },
+        {
+            "id": "RestrictedTestAnnotation",
+            "classifier": {
+                "language": "LionCore-M3",
+                "version": "2024.1",
+                "key": "Annotation"
+            },
+            "properties": [
+                {
+                    "property": {
+                        "language": "LionCore-M3",
+                        "version": "2024.1",
+                        "key": "IKeyed-key"
+                    },
+                    "value": "RestrictedTestAnnotation"
+                },
+                {
+                    "property": {
+                        "language": "LionCore-builtins",
+                        "version": "2024.1",
+                        "key": "LionCore-builtins-INamed-name"
+                    },
+                    "value": "RestrictedTestAnnotation"
+                }
+            ],
+            "containments": [
+                {
+                    "containment": {
+                        "language": "LionCore-M3",
+                        "version": "2024.1",
+                        "key": "Classifier-features"
+                    },
+                    "children": []
+                }
+            ],
+            "references": [
+                {
+                    "reference": {
+                        "language": "LionCore-M3",
+                        "version": "2024.1",
+                        "key": "Annotation-annotates"
+                    },
+                    "targets": [
+                        {
+                            "resolveInfo": "LinkTestConcept",
+                            "reference": "LinkTestConcept"
+                        }
+                    ]
+                },
+                {
+                    "reference": {
+                        "language": "LionCore-M3",
+                        "version": "2024.1",
+                        "key": "Annotation-extends"
+                    },
+                    "targets": []
+                },
+                {
+                    "reference": {
+                        "language": "LionCore-M3",
+                        "version": "2024.1",
+                        "key": "Annotation-implements"
+                    },
+                    "targets": [
+                        {
+                            "resolveInfo": "LionWeb.LionCore_builtins.INamed",
+                            "reference": null
+                        }
+                    ]
+                }
+            ],
+            "annotations": [],
+            "parent": "TestLanguage"
         },
         {
             "id": "TestPartition",

--- a/testLanguage/testLanguage.2026.1.json
+++ b/testLanguage/testLanguage.2026.1.json
@@ -57,6 +57,7 @@
                         "DataTypeTestConcept",
                         "LinkTestConcept",
                         "TestAnnotation",
+                        "RestrictedTestAnnotation",
                         "TestPartition"
                     ]
                 }
@@ -893,7 +894,8 @@
                         "LinkTestConcept-reference_0_1",
                         "LinkTestConcept-reference_1",
                         "LinkTestConcept-reference_0_n",
-                        "LinkTestConcept-reference_1_n"
+                        "LinkTestConcept-reference_1_n",
+                        "LinkTestConcept-otherContainment_0_1"
                     ]
                 }
             ],
@@ -1404,6 +1406,66 @@
             "parent": "LinkTestConcept"
         },
         {
+            "id": "LinkTestConcept-otherContainment_0_1",
+            "classifier": {
+                "language": "LionCore-M3",
+                "version": "2025.1",
+                "key": "Containment"
+            },
+            "properties": [
+                {
+                    "property": {
+                        "language": "LionCore-M3",
+                        "version": "2025.1",
+                        "key": "Link-multiple"
+                    },
+                    "value": "false"
+                },
+                {
+                    "property": {
+                        "language": "LionCore-M3",
+                        "version": "2025.1",
+                        "key": "Feature-optional"
+                    },
+                    "value": "true"
+                },
+                {
+                    "property": {
+                        "language": "LionCore-M3",
+                        "version": "2025.1",
+                        "key": "IKeyed-key"
+                    },
+                    "value": "LinkTestConcept-otherContainment_0_1"
+                },
+                {
+                    "property": {
+                        "language": "LionCore-builtins",
+                        "version": "2025.1",
+                        "key": "LionCore-builtins-INamed-name"
+                    },
+                    "value": "otherContainment_0_1"
+                }
+            ],
+            "containments": [],
+            "references": [
+                {
+                    "reference": {
+                        "language": "LionCore-M3",
+                        "version": "2025.1",
+                        "key": "Link-type"
+                    },
+                    "targets": [
+                        {
+                            "resolveInfo": "LinkTestConcept",
+                            "reference": "LinkTestConcept"
+                        }
+                    ]
+                }
+            ],
+            "annotations": [],
+            "parent": "LinkTestConcept"
+        },
+        {
             "id": "TestAnnotation",
             "classifier": {
                 "language": "LionCore-M3",
@@ -1599,6 +1661,80 @@
             ],
             "annotations": [],
             "parent": "TestAnnotation"
+        },
+        {
+            "id": "RestrictedTestAnnotation",
+            "classifier": {
+                "language": "LionCore-M3",
+                "version": "2025.1",
+                "key": "Annotation"
+            },
+            "properties": [
+                {
+                    "property": {
+                        "language": "LionCore-M3",
+                        "version": "2025.1",
+                        "key": "IKeyed-key"
+                    },
+                    "value": "RestrictedTestAnnotation"
+                },
+                {
+                    "property": {
+                        "language": "LionCore-builtins",
+                        "version": "2025.1",
+                        "key": "LionCore-builtins-INamed-name"
+                    },
+                    "value": "RestrictedTestAnnotation"
+                }
+            ],
+            "containments": [
+                {
+                    "containment": {
+                        "language": "LionCore-M3",
+                        "version": "2025.1",
+                        "key": "Classifier-features"
+                    },
+                    "children": []
+                }
+            ],
+            "references": [
+                {
+                    "reference": {
+                        "language": "LionCore-M3",
+                        "version": "2025.1",
+                        "key": "Annotation-annotates"
+                    },
+                    "targets": [
+                        {
+                            "resolveInfo": "LinkTestConcept",
+                            "reference": "LinkTestConcept"
+                        }
+                    ]
+                },
+                {
+                    "reference": {
+                        "language": "LionCore-M3",
+                        "version": "2025.1",
+                        "key": "Annotation-extends"
+                    },
+                    "targets": []
+                },
+                {
+                    "reference": {
+                        "language": "LionCore-M3",
+                        "version": "2025.1",
+                        "key": "Annotation-implements"
+                    },
+                    "targets": [
+                        {
+                            "resolveInfo": "LionWeb.LionCore_builtins.INamed",
+                            "reference": null
+                        }
+                    ]
+                }
+            ],
+            "annotations": [],
+            "parent": "TestLanguage"
         },
         {
             "id": "TestPartition",

--- a/testLanguage/testLanguage.2026.1.json
+++ b/testLanguage/testLanguage.2026.1.json
@@ -1409,14 +1409,14 @@
             "id": "LinkTestConcept-otherContainment_0_1",
             "classifier": {
                 "language": "LionCore-M3",
-                "version": "2025.1",
+                "version": "2026.1",
                 "key": "Containment"
             },
             "properties": [
                 {
                     "property": {
                         "language": "LionCore-M3",
-                        "version": "2025.1",
+                        "version": "2026.1",
                         "key": "Link-multiple"
                     },
                     "value": "false"
@@ -1424,7 +1424,7 @@
                 {
                     "property": {
                         "language": "LionCore-M3",
-                        "version": "2025.1",
+                        "version": "2026.1",
                         "key": "Feature-optional"
                     },
                     "value": "true"
@@ -1432,7 +1432,7 @@
                 {
                     "property": {
                         "language": "LionCore-M3",
-                        "version": "2025.1",
+                        "version": "2026.1",
                         "key": "IKeyed-key"
                     },
                     "value": "LinkTestConcept-otherContainment_0_1"
@@ -1440,7 +1440,7 @@
                 {
                     "property": {
                         "language": "LionCore-builtins",
-                        "version": "2025.1",
+                        "version": "2026.1",
                         "key": "LionCore-builtins-INamed-name"
                     },
                     "value": "otherContainment_0_1"
@@ -1451,7 +1451,7 @@
                 {
                     "reference": {
                         "language": "LionCore-M3",
-                        "version": "2025.1",
+                        "version": "2026.1",
                         "key": "Link-type"
                     },
                     "targets": [
@@ -1666,14 +1666,14 @@
             "id": "RestrictedTestAnnotation",
             "classifier": {
                 "language": "LionCore-M3",
-                "version": "2025.1",
+                "version": "2026.1",
                 "key": "Annotation"
             },
             "properties": [
                 {
                     "property": {
                         "language": "LionCore-M3",
-                        "version": "2025.1",
+                        "version": "2026.1",
                         "key": "IKeyed-key"
                     },
                     "value": "RestrictedTestAnnotation"
@@ -1681,7 +1681,7 @@
                 {
                     "property": {
                         "language": "LionCore-builtins",
-                        "version": "2025.1",
+                        "version": "2026.1",
                         "key": "LionCore-builtins-INamed-name"
                     },
                     "value": "RestrictedTestAnnotation"
@@ -1691,7 +1691,7 @@
                 {
                     "containment": {
                         "language": "LionCore-M3",
-                        "version": "2025.1",
+                        "version": "2026.1",
                         "key": "Classifier-features"
                     },
                     "children": []
@@ -1701,7 +1701,7 @@
                 {
                     "reference": {
                         "language": "LionCore-M3",
-                        "version": "2025.1",
+                        "version": "2026.1",
                         "key": "Annotation-annotates"
                     },
                     "targets": [
@@ -1714,7 +1714,7 @@
                 {
                     "reference": {
                         "language": "LionCore-M3",
-                        "version": "2025.1",
+                        "version": "2026.1",
                         "key": "Annotation-extends"
                     },
                     "targets": []
@@ -1722,7 +1722,7 @@
                 {
                     "reference": {
                         "language": "LionCore-M3",
-                        "version": "2025.1",
+                        "version": "2026.1",
                         "key": "Annotation-implements"
                     },
                     "targets": [

--- a/testLanguage/testLanguage.puml
+++ b/testLanguage/testLanguage.puml
@@ -17,6 +17,9 @@ class DataTypeTestConcept {
 
 class LinkTestConcept implements INamed
 
+annotation RestrictedTestAnnotation implements INamed
+RestrictedTestAnnotation ..# LinkTestConcept : <i>annotates</i>
+
 enum SecondTestEnumeration {
   literal1
   literal2
@@ -47,6 +50,8 @@ LinkTestConcept "*" --> "0..1" LinkTestConcept: reference_0_1
 LinkTestConcept "*" --> "1" LinkTestConcept: reference_1
 LinkTestConcept "*" --> "*" LinkTestConcept: reference_0_n
 LinkTestConcept "*" --> "*" LinkTestConcept: reference_1_n
+LinkTestConcept "1" o--> "0..1" LinkTestConcept: otherContainment_0_1
+
 
 TestAnnotation "*" --> "1" Node: ref
 TestAnnotation "1" o--> "0..1" Node: containment

--- a/testLanguage/testLanguage.txt
+++ b/testLanguage/testLanguage.txt
@@ -19,10 +19,14 @@ language TestLanguage
                 containment_0_n: LinkTestConcept[0..*]
                 containment_1: LinkTestConcept
                 containment_1_n: LinkTestConcept[1..*]
+                otherContainment_0_1: LinkTestConcept?
                 reference_0_1 -> LinkTestConcept?
                 reference_0_n -> LinkTestConcept[0..*]
                 reference_1 -> LinkTestConcept
                 reference_1_n -> LinkTestConcept[1..*]
+
+        annotation RestrictedTestAnnotation implements INamed
+            annotates: LinkTestConcept
 
         enumeration SecondTestEnumeration
             literals:

--- a/ts/scripts/generate-test-language.ts
+++ b/ts/scripts/generate-test-language.ts
@@ -157,5 +157,5 @@ writeFileSync(`${languagesPath}/testLanguage.2024.1.json`, jsonAsText(serialized
 // modify version for 2026.1 version, and persist:
 setVersion(serializedTestLanguage, "2026.1")
 // Note: reference objects were already modified to comply with the specification in the previous step!
-await Deno.writeTextFile(`${languagesPath}/testLanguage.2026.1.json`, jsonAsText(serializedTestLanguage))
+writeFileSync(`${languagesPath}/testLanguage.2026.1.json`, jsonAsText(serializedTestLanguage))
 console.log(`Generated artifacts for test language.`)

--- a/ts/scripts/generate-test-language.ts
+++ b/ts/scripts/generate-test-language.ts
@@ -157,8 +157,5 @@ writeFileSync(`${languagesPath}/testLanguage.2024.1.json`, jsonAsText(serialized
 // modify version for 2026.1 version, and persist:
 setVersion(serializedTestLanguage, "2026.1")
 // Note: reference objects were already modified to comply with the specification in the previous step!
-writeFileSync(`${languagesPath}/testLanguage.2026.1.json`, jsonAsText(serializedTestLanguage))
-
-
+await Deno.writeTextFile(`${languagesPath}/testLanguage.2026.1.json`, jsonAsText(serializedTestLanguage))
 console.log(`Generated artifacts for test language.`)
-

--- a/ts/scripts/generate-test-language.ts
+++ b/ts/scripts/generate-test-language.ts
@@ -93,10 +93,16 @@ linkTypes.forEach((linkType) => {
 })
 
 
+// add a second single-optional containment:
+factory.containment(LinkTestConcept, "otherContainment_0_1").ofType(LinkTestConcept).isOptional()
+
 // generate a test annotation:
 const TestAnnotation = factory.annotation("TestAnnotation").annotating(builtinClassifiers.node).implementing(builtinClassifiers.inamed)
 factory.reference(TestAnnotation, "ref").ofType(builtinClassifiers.node)
 factory.containment(TestAnnotation, "containment").ofType(builtinClassifiers.node).isOptional()
+
+// generate a restricted annotation that only annotates LinkTestConcept (not Node):
+factory.annotation("RestrictedTestAnnotation").annotating(LinkTestConcept).implementing(builtinClassifiers.inamed)
 
 // generate a test partition:
 const TestPartition = factory.concept("TestPartition", false).implementing(builtinClassifiers.inamed).isPartition()


### PR DESCRIPTION
- Add optional single containment `otherContainment_0_1` to LinkTestConcept
- Add RestrictedTestAnnotation that only annotates LinkTestConcept (not all Nodes)
- Update test language JSON definitions across all versions (2023.1, 2024.1, 2025.1)
- Regenerate test language documentation (PlantUML and text formats)